### PR TITLE
Only use space for non-unit weights

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,8 +3,6 @@ version: "build-{build}"
 environment:
   matrix:
   - VS_VERSION: 14
-    VS_PLATFORM: win32
-  - VS_VERSION: 14
     VS_PLATFORM: x64
 
 branches:
@@ -18,14 +16,14 @@ install:
   - git submodule update --init --recursive
 
 before_build:
-  - md build-release
-  - cd build-release
-  - cmake -G "Visual Studio %VS_VERSION%" -DSTATIC=1 -DCMAKE_VERBOSE_MAKEFILE=1 -DTESTS=1 ../
+  - md build-debug
+  - cd build-debug
+  - cmake -G "Visual Studio %VS_VERSION%" -DDEBUG=1 -DSTATIC=1 -DCMAKE_VERBOSE_MAKEFILE=1 -DTESTS=1 ../
   - cd ../
 
 build_script:
-  - cd build-release
-  - cmake --build . --config Release
-  - ctest . -C Release --output-on-failure
+  - cd build-debug
+  - cmake --build . --config Debug 
+  - ctest . -C Debug --output-on-failure
   - cd ../
 

--- a/src/Poros.cpp
+++ b/src/Poros.cpp
@@ -72,8 +72,8 @@ int POROS_PartGraphRecursive(
     vtx_type const numVertices,
     adj_type const * const edgePrefix,
     vtx_type const * const edgeList,
-    wgt_type const * vertexWeights,
-    wgt_type const * edgeWeights,
+    wgt_type const * const vertexWeights,
+    wgt_type const * const edgeWeights,
     pid_type const numPartitions,
     poros_options_struct const * const options,
     wgt_type * const totalCutEdgeWeight,
@@ -93,18 +93,6 @@ int POROS_PartGraphRecursive(
 
   // create a parameters object
   RandomEngineHandle randEngine = globalParams.randomEngine();
-
-  // allocate unit edge weights and vertex weights of needed
-  sl::Array<wgt_type> unitVwgts;
-  if (vertexWeights == nullptr) {
-    unitVwgts = sl::Array<wgt_type>(numVertices, 1);
-    vertexWeights = unitVwgts.data();
-  }
-  sl::Array<wgt_type> unitEwgts;
-  if (edgeWeights == nullptr) {
-    unitEwgts = sl::Array<wgt_type>(edgePrefix[numVertices], 1);
-    edgeWeights = unitEwgts.data();
-  }
 
   // assemble a new graph
   Graph baseGraph(numVertices, edgePrefix[numVertices], edgePrefix, \

--- a/src/aggregation/HeavyEdgeMatchingAggregator.cpp
+++ b/src/aggregation/HeavyEdgeMatchingAggregator.cpp
@@ -31,9 +31,6 @@
 #include "graph/DegreeSortedVertexSet.hpp"
 
 
-#include <iostream>
-#include "solidutils/Timer.hpp"
-
 namespace poros
 {
 
@@ -62,9 +59,6 @@ Aggregation HeavyEdgeMatchingAggregator::aggregate(
     Graph const * const graph)
 {
   MatchedAggregationBuilder matcher(graph->numVertices());
-
-  sl::Timer tmr;
-  tmr.start();
 
   PermutedVertexSet permutedVertices = \
       DegreeSortedVertexSet::ascendingRandom(graph->vertices(), graph, \
@@ -95,9 +89,6 @@ Aggregation HeavyEdgeMatchingAggregator::aggregate(
       }
     }
   }
-
-  tmr.stop();
-  std::cout << "SHEM took " << tmr.poll() << std::endl;
 
   return matcher.build();
 }

--- a/src/aggregation/RandomMatchingAggregator.cpp
+++ b/src/aggregation/RandomMatchingAggregator.cpp
@@ -36,6 +36,46 @@ namespace poros
 
 
 /******************************************************************************
+* HELPER FUNCTIONS ************************************************************
+******************************************************************************/
+
+template<bool HAS_VERTEX_WEIGHTS>
+void firstMatch(
+    AggregationParameters const params,
+    Graph const * const graph,
+    PermutedVertexSet const permutedVertices,
+    MatchedAggregationBuilder * const matcher)
+{
+  for (Vertex const vertex : permutedVertices) {
+    vtx_type const v = vertex.index;
+    if (!matcher->isMatched(v)) {
+      // we'll choose our neighbor randomly by finding the one with the highest
+      // index in the permutation array
+      vtx_type max = NULL_VTX;
+      vtx_type const vertexWeight = graph->weightOf<HAS_VERTEX_WEIGHTS>(vertex);
+      vtx_type maxPriority = 0;
+      for (Edge const edge : graph->edgesOf(vertex)) {
+        Vertex const u = graph->destinationOf(edge);
+        wgt_type const coarseWeight = \
+            vertexWeight + graph->weightOf<HAS_VERTEX_WEIGHTS>(u);
+        if (!matcher->isMatched(u.index) && \
+            params.isAllowedVertexWeight(coarseWeight)) {
+          vtx_type const priority = permutedVertices[u.index].index;
+          if (max == NULL_VTX || maxPriority < priority) {
+            maxPriority = priority;
+            max = u.index;
+            break;
+          }
+        }
+      }
+      if (max != NULL_VTX) {
+        matcher->match(v, max);
+      }
+    }
+  }
+}
+
+/******************************************************************************
 * CONSTRUCTORS / DESTRUCTOR ***************************************************
 ******************************************************************************/
 
@@ -68,32 +108,10 @@ Aggregation RandomMatchingAggregator::aggregate(
   PermutedVertexSet permutedVertices = RandomOrderVertexSet::generate(
       graph->vertices(), m_rng.get());
 
-  for (Vertex const vertex : permutedVertices) {
-    vtx_type const v = vertex.index;
-    if (!matcher.isMatched(v)) {
-      // we'll choose our neighbor randomly by finding the one with the highest
-      // index in the permutation array
-      vtx_type max = NULL_VTX;
-      vtx_type const vertexWeight = graph->weightOf(vertex);
-      vtx_type maxPriority = 0;
-      for (Edge const edge : graph->edgesOf(vertex)) {
-        Vertex const u = graph->destinationOf(edge);
-        wgt_type const coarseWeight = \
-            vertexWeight + graph->weightOf(u);
-        if (!matcher.isMatched(u.index) && \
-            params.isAllowedVertexWeight(coarseWeight)) {
-          vtx_type const priority = permutedVertices[u.index].index;
-          if (max == NULL_VTX || maxPriority < priority) {
-            maxPriority = priority;
-            max = u.index;
-            break;
-          }
-        }
-      }
-      if (max != NULL_VTX) {
-        matcher.match(v, max);
-      }
-    }
+  if (graph->hasUnitVertexWeight()) {
+    firstMatch<false>(params, graph, std::move(permutedVertices), &matcher);
+  } else {
+    firstMatch<true>(params, graph, std::move(permutedVertices), &matcher);
   }
 
   return matcher.build();

--- a/src/aggregation/RandomMatchingAggregator.cpp
+++ b/src/aggregation/RandomMatchingAggregator.cpp
@@ -31,9 +31,6 @@
 #include "aggregation/MatchedAggregationBuilder.hpp"
 #include "graph/RandomOrderVertexSet.hpp"
 
-#include <iostream>
-#include "solidutils/Timer.hpp"
-
 namespace poros
 {
 
@@ -68,9 +65,6 @@ Aggregation RandomMatchingAggregator::aggregate(
 {
   MatchedAggregationBuilder matcher(graph->numVertices());
 
-  sl::Timer tmr;
-  tmr.start();
-
   PermutedVertexSet permutedVertices = RandomOrderVertexSet::generate(
       graph->vertices(), m_rng.get());
 
@@ -101,9 +95,6 @@ Aggregation RandomMatchingAggregator::aggregate(
       }
     }
   }
-
-  tmr.stop();
-  std::cout << "RM took " << tmr.poll() << std::endl;
 
   return matcher.build();
 }

--- a/src/aggregation/SHEMRMAggregator.cpp
+++ b/src/aggregation/SHEMRMAggregator.cpp
@@ -52,7 +52,7 @@ Aggregation SHEMRMAggregator::aggregate(
     AggregationParameters const params,
     Graph const * const graph)
 {
-  if (graph->hasUniformEdgeWeight()) {
+  if (graph->hasUnitEdgeWeight()) {
     return m_rm.aggregate(params, graph);
   } else {
     return m_shem.aggregate(params, graph);

--- a/src/aggregation/SummationContractor.cpp
+++ b/src/aggregation/SummationContractor.cpp
@@ -44,7 +44,7 @@ namespace poros
 namespace
 {
 
-template<bool UNIT_VERTICES, bool UNIT_EDGES>
+template<bool HAS_VERTEX_WEIGHTS, bool HAS_EDGE_WEIGHTS>
 GraphHandle contractGraph(
     Graph const * const graph,
     Aggregation const * const aggregation)
@@ -58,20 +58,13 @@ GraphHandle contractGraph(
     wgt_type coarseVertexWeight = 0;
 
     for (Vertex const vertex : group.fineVertices()) {
-      if (UNIT_VERTICES) {
-        coarseVertexWeight += static_cast<wgt_type>(1);
-      } else {
-        coarseVertexWeight += graph->weightOf(vertex);
-      }
+      coarseVertexWeight += graph->weightOf<HAS_VERTEX_WEIGHTS>(vertex);
       for (Edge const edge : graph->edgesOf(vertex)) {
         vtx_type const coarseNeighbor = aggregation->getCoarseVertexNumber(
             graph->destinationOf(edge).index);
         if (coarseVertex != coarseNeighbor) {
-          if (UNIT_EDGES) {
-            builder.addEdge(coarseNeighbor, static_cast<wgt_type>(1));
-          } else {
-            builder.addEdge(coarseNeighbor, graph->weightOf(edge));
-          }
+          wgt_type const ewgt = graph->weightOf<HAS_EDGE_WEIGHTS>(edge);
+          builder.addEdge(coarseNeighbor, ewgt);
         }
       }
     }
@@ -84,10 +77,6 @@ GraphHandle contractGraph(
 
   return next;
 }
-
-
-
-
 
 
 }
@@ -117,15 +106,15 @@ GraphHandle SummationContractor::contract(
 {
   if (graph->hasUnitVertexWeight()) {
     if (graph->hasUnitEdgeWeight()) {
-      return contractGraph<true, true>(graph, aggregation);
+      return contractGraph<false, false>(graph, aggregation);
     } else {
-      return contractGraph<true, false>(graph, aggregation);
+      return contractGraph<false, true>(graph, aggregation);
     }
   } else {
     if (graph->hasUnitEdgeWeight()) {
-      return contractGraph<false, true>(graph, aggregation);
+      return contractGraph<true, false>(graph, aggregation);
     } else {
-      return contractGraph<false, false>(graph, aggregation);
+      return contractGraph<true, true>(graph, aggregation);
     }
   }
 }

--- a/src/aggregation/test/HeavyEdgeMatchingAggregator_test.cpp
+++ b/src/aggregation/test/HeavyEdgeMatchingAggregator_test.cpp
@@ -38,6 +38,7 @@ namespace poros
 UNITTEST(HeavyEdgeMatchingAggregator, LimitTwoMatch)
 {
   GridGraphGenerator gen(30,40,50);
+  gen.setRandomEdgeWeight(1,3);
   Graph graph = gen.generate();
 
   RandomEngineHandle rand = RandomEngineFactory::make(0);
@@ -53,7 +54,7 @@ UNITTEST(HeavyEdgeMatchingAggregator, LimitTwoMatch)
 
   // verify at most two vertices per coarse vertex
   std::vector<int> matchCount(agg.getNumCoarseVertices(), 0);
-  for (Vertex const & vertex : graph.vertices()) {
+  for (Vertex const vertex : graph.vertices()) {
     vtx_type const coarse = agg.getCoarseVertexNumber(vertex.index);
     ++matchCount[coarse];
   }
@@ -67,6 +68,7 @@ UNITTEST(HeavyEdgeMatchingAggregator, LimitTwoMatch)
 UNITTEST(HeavyEdgeMatchingAggregator, ConnectedMatch)
 {
   GridGraphGenerator gen(30,40,50);
+  gen.setRandomEdgeWeight(1,3);
   Graph graph = gen.generate();
 
   RandomEngineHandle rand = RandomEngineFactory::make(0);
@@ -102,6 +104,7 @@ UNITTEST(HeavyEdgeMatchingAggregator, ConnectedMatch)
 UNITTEST(HeavyEdgeMatchingAggregator, MaxSize)
 {
   GridGraphGenerator gen(30,40,50);
+  gen.setRandomEdgeWeight(1,3);
   Graph graph = gen.generate();
 
   RandomEngineHandle rand = RandomEngineFactory::make(0);

--- a/src/aggregation/test/SummationContractor_test.cpp
+++ b/src/aggregation/test/SummationContractor_test.cpp
@@ -71,7 +71,7 @@ UNITTEST(SummationContractor, ContractLine)
   testEqual(out->degreeOf(Vertex::make(7)), static_cast<vtx_type>(1));
 
   for (Edge const & edge : out->edges()) {
-    testEqual(out->weightOf(edge), static_cast<wgt_type>(2));
+    testEqual(out->weightOf<true>(edge), static_cast<wgt_type>(2));
   }
 }
 
@@ -150,7 +150,7 @@ UNITTEST(SummationContractor, ContractCubeSquare)
   testEqual(out->getTotalEdgeWeight(), static_cast<wgt_type>(16));
 
   for (Edge const & edge : out->edges()) {
-    testEqual(out->weightOf(edge), static_cast<wgt_type>(2));
+    testEqual(out->weightOf<true>(edge), static_cast<wgt_type>(2));
   }
 }
 

--- a/src/graph/Graph.cpp
+++ b/src/graph/Graph.cpp
@@ -63,8 +63,8 @@ Graph::Graph(
     sl::ConstArray<vtx_type> edgeList,
     sl::ConstArray<wgt_type> vertexWeight,
     sl::ConstArray<wgt_type> edgeWeight) :
-  m_uniformEdgeWeight(true),
-  m_uniformVertexWeight(true),
+  m_unitEdgeWeight(true),
+  m_unitVertexWeight(true),
   m_numVertices(edgePrefix.size()-1),
   m_numEdges(edgeList.size()),
   m_totalVertexWeight(0),
@@ -77,17 +77,16 @@ Graph::Graph(
   // calculate total vertex weight
   if (m_numVertices > 0) {
     if (m_vertexWeight.data() == nullptr) {
-      // allocate uniform vertex weight
+      // allocate unit vertex weight
       m_vertexWeight = sl::Array<vtx_type>(m_numVertices, 1);
-      m_uniformVertexWeight = true;
+      m_unitVertexWeight = true;
     } else {
-      const wgt_type baseVertexWeight = m_vertexWeight[0];
       for (vtx_type v = 0; v < m_numVertices; ++v) {
         const wgt_type vwgt = m_vertexWeight[v];
         m_totalVertexWeight += vwgt;
 
-        if (vwgt != baseVertexWeight) {
-          m_uniformVertexWeight = false;
+        if (vwgt != static_cast<wgt_type>(1)) {
+          m_unitVertexWeight = false;
         }
       }
     }
@@ -96,17 +95,16 @@ Graph::Graph(
   // calculate total edge weight
   if (m_numEdges > 0) {
     if (m_edgeWeight.data() == nullptr) {
-      // allocate uniform edge weight
+      // allocate unit edge weight
       m_edgeWeight = sl::Array<wgt_type>(m_numEdges, 1);
-      m_uniformEdgeWeight = true;
+      m_unitEdgeWeight = true;
     } else {
-      const wgt_type baseEdgeWeight = m_edgeWeight[0];
       for (adj_type e = 0; e < m_numEdges; ++e) {
         const wgt_type ewgt = m_edgeWeight[e];
         m_totalEdgeWeight += ewgt;
 
-        if (ewgt != baseEdgeWeight) {
-          m_uniformEdgeWeight = false;
+        if (ewgt != static_cast<wgt_type>(1)) {
+          m_unitEdgeWeight = false;
         }
       }
     }
@@ -118,8 +116,8 @@ Graph::Graph(
 
 Graph::Graph(
     Graph && lhs) noexcept :
-  m_uniformEdgeWeight(lhs.m_uniformEdgeWeight),
-  m_uniformVertexWeight(lhs.m_uniformVertexWeight),
+  m_unitEdgeWeight(lhs.m_unitEdgeWeight),
+  m_unitVertexWeight(lhs.m_unitVertexWeight),
   m_numVertices(lhs.m_numVertices),
   m_numEdges(lhs.m_numEdges),
   m_totalVertexWeight(lhs.m_totalVertexWeight),

--- a/src/graph/Graph.cpp
+++ b/src/graph/Graph.cpp
@@ -41,6 +41,24 @@ namespace poros
 
 
 /******************************************************************************
+* HELPER FUNCTIONS ************************************************************
+******************************************************************************/
+
+template<typename T>
+sl::ConstArray<T> emptyIfNull(
+    T const * const ptr,
+    size_t const size)
+{
+  if (ptr != nullptr) {
+    return sl::ConstArray<T>(ptr, size);
+  } else {
+    return sl::ConstArray<T>(nullptr, 0);
+  }
+}
+    
+
+
+/******************************************************************************
 * CONSTRUCTORS / DESTRUCTOR ***************************************************
 ******************************************************************************/
 
@@ -54,8 +72,8 @@ Graph::Graph(
     wgt_type const * const edgeWeight) :
   Graph(sl::ConstArray<adj_type>(edgePrefix, numVertices+1),
         sl::ConstArray<vtx_type>(edgeList, numEdges),
-        sl::ConstArray<wgt_type>(vertexWeight, numVertices),
-        sl::ConstArray<wgt_type>(edgeWeight, numEdges))
+        emptyIfNull(vertexWeight, numVertices),
+        emptyIfNull(edgeWeight, numEdges))
 {
   // do nothing
 }
@@ -82,6 +100,7 @@ Graph::Graph(
     if (m_vertexWeight.size() == 0) {
       // allocate unit vertex weight
       m_unitVertexWeight = true;
+      m_totalVertexWeight = static_cast<wgt_type>(m_numVertices);
     } else {
       for (vtx_type v = 0; v < m_numVertices; ++v) {
         const wgt_type vwgt = m_vertexWeight[v];
@@ -99,6 +118,7 @@ Graph::Graph(
     if (m_edgeWeight.size() == 0) {
       // allocate unit edge weight
       m_unitEdgeWeight = true;
+      m_totalEdgeWeight = static_cast<wgt_type>(m_numEdges);
     } else {
       for (adj_type e = 0; e < m_numEdges; ++e) {
         const wgt_type ewgt = m_edgeWeight[e];

--- a/src/graph/Graph.hpp
+++ b/src/graph/Graph.hpp
@@ -293,23 +293,23 @@ class Graph
     }
 
     /**
-    * @brief Check if the graph has uniform edge weights.
+    * @brief Check if the graph has unit edge weights.
     *
     * @return True if the edge weights are all equal.
     */
-    bool hasUniformEdgeWeight() const noexcept
+    bool hasUnitEdgeWeight() const noexcept
     {
-      return m_uniformEdgeWeight;
+      return m_unitEdgeWeight;
     }
 
     /**
-    * @brief Check if the graph has uniform vertex weights.
+    * @brief Check if the graph has unit vertex weights.
     *
     * @return True if the vertex weights are all equal.
     */
-    bool hasUniformVertexWeight() const noexcept
+    bool hasUnitVertexWeight() const noexcept
     {
-      return m_uniformVertexWeight;
+      return m_unitVertexWeight;
     }
 
    
@@ -323,8 +323,8 @@ class Graph
     #endif
 
   private:
-    bool m_uniformEdgeWeight;
-    bool m_uniformVertexWeight;
+    bool m_unitEdgeWeight;
+    bool m_unitVertexWeight;
 
     vtx_type m_numVertices;
     adj_type m_numEdges;

--- a/src/graph/Graph.hpp
+++ b/src/graph/Graph.hpp
@@ -273,10 +273,17 @@ class Graph
     *
     * @return The weight.
     */
+    template<bool HAS_EDGE_WEIGHT>
     wgt_type weightOf(
         Edge const e) const noexcept
     {
-      return m_edgeWeight[e.index];
+      ASSERT_EQUAL(HAS_EDGE_WEIGHT, !hasUnitEdgeWeight());
+      if (HAS_EDGE_WEIGHT) {
+        return m_edgeWeight[e.index];
+      } else {
+        return static_cast<wgt_type>(1);
+      }
+
     }
 
     /**
@@ -286,10 +293,16 @@ class Graph
     *
     * @return The weight.
     */
+    template<bool HAS_VERTEX_WEIGHT>
     wgt_type weightOf(
         Vertex const v) const noexcept
     {
-      return m_vertexWeight[v.index];
+      ASSERT_EQUAL(HAS_VERTEX_WEIGHT, !hasUnitVertexWeight());
+      if (HAS_VERTEX_WEIGHT) {
+        return m_vertexWeight[v.index];
+      } else {
+        return static_cast<wgt_type>(1);
+      }
     }
 
     /**

--- a/src/graph/TwoStepGraphBuilder.cpp
+++ b/src/graph/TwoStepGraphBuilder.cpp
@@ -44,6 +44,8 @@ TwoStepGraphBuilder::TwoStepGraphBuilder() :
   m_phase(PHASE_START),
   m_numVertices(0),
   m_numEdges(0),
+  m_unitVertexWeight(false),
+  m_unitEdgeWeight(false),
   m_edgePrefix(0),
   m_edgeList(0),
   m_vertexWeight(0),
@@ -69,6 +71,17 @@ void TwoStepGraphBuilder::setNumVertices(
   m_numVertices = numVertices;
 }
 
+void TwoStepGraphBuilder::setUnitVertexWeight(
+    bool const hasUnitWeight)
+{
+  m_unitVertexWeight = hasUnitWeight;
+}
+
+void TwoStepGraphBuilder::setUnitEdgeWeight(
+    bool const hasUnitWeight)
+{
+  m_unitEdgeWeight = hasUnitWeight;
+}
 
 void TwoStepGraphBuilder::beginVertexPhase()
 {
@@ -77,7 +90,9 @@ void TwoStepGraphBuilder::beginVertexPhase()
   
   // allocate vertex arrays
   m_edgePrefix = sl::Array<adj_type>(m_numVertices+1, 0);
-  m_vertexWeight = sl::Array<wgt_type>(m_numVertices);
+  if (!m_unitVertexWeight) {
+    m_vertexWeight = sl::Array<wgt_type>(m_numVertices);
+  }
 }
 
 
@@ -97,7 +112,10 @@ void TwoStepGraphBuilder::beginEdgePhase()
 
   // allocate edge arrays
   m_edgeList = sl::Array<vtx_type>(m_numEdges);
-  m_edgeWeight = sl::Array<wgt_type>(m_numEdges);
+
+  if (!m_unitEdgeWeight) {
+    m_edgeWeight = sl::Array<wgt_type>(m_numEdges);
+  }
 }
 
 

--- a/src/graph/TwoStepGraphBuilder.hpp
+++ b/src/graph/TwoStepGraphBuilder.hpp
@@ -111,7 +111,7 @@ class TwoStepGraphBuilder
     * @param vertex The vertex.
     * @param numEdges The number of edges.
     */
-    inline void setVertexNumEdges(
+    void setVertexNumEdges(
         vtx_type const vertex,
         adj_type const numEdges) noexcept
     {
@@ -127,7 +127,7 @@ class TwoStepGraphBuilder
     *
     * @param vertex The vertex.
     */
-    inline void incVertexNumEdges(
+    void incVertexNumEdges(
         vtx_type const vertex) noexcept
     {
       ASSERT_EQUAL(m_phase, PHASE_VERTICES);
@@ -145,7 +145,7 @@ class TwoStepGraphBuilder
     * @param vertex The vertex to set the weight of.
     * @param weight The weight of the vertex.
     */
-    inline void setVertexWeight(
+    void setVertexWeight(
         vtx_type const vertex,
         wgt_type const weight) noexcept
     {
@@ -163,7 +163,7 @@ class TwoStepGraphBuilder
     * @param dest The vertex at the other end of the edge.
     * @param weight The weight of the edge.  
     */
-    inline void addEdgeToVertex(
+    void addEdgeToVertex(
         vtx_type const vertex,
         vtx_type const dest,
         wgt_type const weight) noexcept

--- a/src/graph/TwoStepGraphBuilder.hpp
+++ b/src/graph/TwoStepGraphBuilder.hpp
@@ -89,6 +89,21 @@ class TwoStepGraphBuilder
     */
     GraphHandle finish();
 
+    /**
+    * @brief Generate the graph with vertex with weight 1.
+    *
+    * @param hasUnitWeights Whether or not the graph has vertex weights of 1.
+    */
+    void setUnitVertexWeight(
+        bool hasUnitWeights);
+
+    /**
+    * @brief Generate the graph with edge with weight 1.
+    *
+    * @param hasUnitWeights Whether or not the graph has edge weights of 1.
+    */
+    void setUnitEdgeWeight(
+        bool hasUnitWeights);
 
     /**
     * @brief Set the number of edges this vertex will have.
@@ -135,6 +150,7 @@ class TwoStepGraphBuilder
         wgt_type const weight) noexcept
     {
       ASSERT_EQUAL(m_phase, PHASE_VERTICES);
+      ASSERT_FALSE(m_unitVertexWeight);
 
       m_vertexWeight[vertex] = weight;
     }
@@ -159,7 +175,9 @@ class TwoStepGraphBuilder
 
       adj_type const index = m_edgePrefix[vertex+1]++;
       m_edgeList[index] = dest;
-      m_edgeWeight[index] = weight;
+      if (!m_unitEdgeWeight) {
+        m_edgeWeight[index] = weight;
+      }
     }
 
 
@@ -167,6 +185,8 @@ class TwoStepGraphBuilder
     int m_phase;
     vtx_type m_numVertices;
     adj_type m_numEdges;
+    bool m_unitVertexWeight;
+    bool m_unitEdgeWeight;
     sl::Array<adj_type> m_edgePrefix;
     sl::Array<vtx_type> m_edgeList;
     sl::Array<wgt_type> m_vertexWeight;

--- a/src/graph/test/TwoStepGraphBuilder_test.cpp
+++ b/src/graph/test/TwoStepGraphBuilder_test.cpp
@@ -77,11 +77,11 @@ UNITTEST(TwoStepGraphBuilder, FullBuild)
   testEqual(graph->numEdges(), 8u);
 
   for (Vertex const vertex : graph->vertices()) {
-    testEqual(graph->weightOf(vertex), 1u);
+    testEqual(graph->weightOf<true>(vertex), 1u);
     testEqual(graph->degreeOf(vertex), 2u);
 
     for (Edge const edge : graph->edgesOf(vertex)) {
-      testEqual(graph->weightOf(edge), 2u);
+      testEqual(graph->weightOf<true>(edge), 2u);
     }
   }
 }

--- a/src/graph/test/TwoStepGraphBuilder_test.cpp
+++ b/src/graph/test/TwoStepGraphBuilder_test.cpp
@@ -77,7 +77,7 @@ UNITTEST(TwoStepGraphBuilder, FullBuild)
   testEqual(graph->numEdges(), 8u);
 
   for (Vertex const vertex : graph->vertices()) {
-    testEqual(graph->weightOf<true>(vertex), 1u);
+    testEqual(graph->weightOf<false>(vertex), 1u);
     testEqual(graph->degreeOf(vertex), 2u);
 
     for (Edge const edge : graph->edgesOf(vertex)) {

--- a/src/multilevel/test/DiscreteCoarseGraph_test.cpp
+++ b/src/multilevel/test/DiscreteCoarseGraph_test.cpp
@@ -68,9 +68,9 @@ UNITTEST(DiscreteCoarseGraph, Contract)
 
   // check edge and vertex weights
   for (Vertex const vertex : coarseGraph->vertices()) {
-    testEqual(coarseGraph->weightOf(vertex), static_cast<wgt_type>(2));
+    testEqual(coarseGraph->weightOf<true>(vertex), static_cast<wgt_type>(2));
     for (Edge const edge : coarseGraph->edgesOf(vertex)) {
-      testEqual(coarseGraph->weightOf(edge), static_cast<wgt_type>(2));
+      testEqual(coarseGraph->weightOf<true>(edge), static_cast<wgt_type>(2));
       testEqual(std::abs(static_cast<int>(coarseGraph->destinationOf(edge).index)
           - static_cast<int>(vertex.index)), 1);
     }

--- a/src/partition/MultilevelBisector.cpp
+++ b/src/partition/MultilevelBisector.cpp
@@ -35,8 +35,6 @@
 
 #include "solidutils/Timer.hpp"
 
-#include <iostream>
-
 namespace poros
 {
 
@@ -107,12 +105,6 @@ PartitioningInformation MultilevelBisector::recurse(
       " vertices and " + std::to_string(graph->numEdges()) +
       " edges, with an exposed weight of " +
       std::to_string(graph->getTotalEdgeWeight()) + ".");
-
-   std::cout << "Coarsened graph to " +
-      std::to_string(graph->numVertices()) +
-      " vertices and " + std::to_string(graph->numEdges()) +
-      " edges, with an exposed weight of " +
-      std::to_string(graph->getTotalEdgeWeight()) + "." << std::endl;
 
   if (stoppingCriteria->shouldStop(level, parent, graph)) {
     Partitioning part = m_initialBisector->execute(target, graph); 

--- a/src/partition/Partitioning.hpp
+++ b/src/partition/Partitioning.hpp
@@ -60,24 +60,24 @@ class Partitioning
           // do nothing
         }
 
-        inline Partition operator*() const
+        Partition operator*() const
         {
           return Partition(m_index, m_partitionWeight[m_index]);
         }
 
-        inline Iterator & operator++()
+        Iterator & operator++()
         {
           ++m_index;
           return *this;
         }
 
-        inline bool operator==(
+        bool operator==(
             Iterator const & other) const
         {
           return m_index == other.m_index;
         }
 
-        inline bool operator!=(
+        bool operator!=(
             Iterator const & other) const
         {
           return m_index != other.m_index;
@@ -209,7 +209,7 @@ class Partitioning
     *
     * @return The partition.
     */
-    inline Partition operator[](
+    Partition operator[](
         pid_type const part) const noexcept
     {
       return Partition(part, m_partitionWeight[part]);
@@ -221,7 +221,7 @@ class Partitioning
     *
     * @param weight The cut edge weight.
     */
-    inline void setCutEdgeWeight(
+    void setCutEdgeWeight(
         wgt_type const weight) noexcept
     {
       m_cutEdgeWeight = weight;
@@ -233,7 +233,7 @@ class Partitioning
     *
     * @param weightDelta The cut edge weight delta.
     */
-    inline void addCutEdgeWeight(
+    void addCutEdgeWeight(
         wgt_type const weightDelta) noexcept
     {
       m_cutEdgeWeight += weightDelta;
@@ -245,7 +245,7 @@ class Partitioning
     *
     * @return The weight.
     */
-    inline wgt_type getCutEdgeWeight() const noexcept
+    wgt_type getCutEdgeWeight() const noexcept
     {
       return m_cutEdgeWeight;
     }
@@ -256,7 +256,7 @@ class Partitioning
      *
      * @return The number of partitions. 
      */
-    inline pid_type numPartitions() const noexcept
+    pid_type numPartitions() const noexcept
     {
       return static_cast<pid_type>(m_partitionWeight.size());
     }
@@ -269,7 +269,7 @@ class Partitioning
      * @param vertex The vertex.
      * @param partition The partition to assign it to.
      */
-    inline void assign(
+    void assign(
         Vertex const vertex,
         pid_type const partition) noexcept
     {
@@ -279,7 +279,8 @@ class Partitioning
       ASSERT_LESS(partition, m_partitionWeight.size());
       ASSERT_EQUAL(getAssignment(vertex), NULL_PID);
 
-      wgt_type const weight = m_graph->weightOf(vertex);
+      wgt_type const weight = m_graph->hasUnitVertexWeight() ? \
+          m_graph->weightOf<false>(vertex) : m_graph->weightOf<true>(vertex);
 
       m_partitionWeight[partition] += weight;
       m_assignment[index] = partition;
@@ -292,7 +293,7 @@ class Partitioning
      * @param vertex The vertex to move.
      * @param partition The partition to move the vertex to.
      */
-    inline void move(
+    void move(
         Vertex const vertex,
         pid_type const partition) noexcept
     {
@@ -303,7 +304,8 @@ class Partitioning
       ASSERT_NOTEQUAL(getAssignment(vertex), NULL_PID);
       ASSERT_NOTEQUAL(getAssignment(vertex), partition);
 
-      wgt_type const weight = m_graph->weightOf(vertex);
+      wgt_type const weight = m_graph->hasUnitVertexWeight() ? \
+          m_graph->weightOf<false>(vertex) : m_graph->weightOf<true>(vertex);
 
       // remove from previous partition
       pid_type const current = getAssignment(vertex);
@@ -321,7 +323,7 @@ class Partitioning
      * @param vertex The vertex to unassign.
      * @param weight The weight of the vertex.
      */
-    inline void unassign(
+    void unassign(
         Vertex const vertex) noexcept
     {
       vtx_type const index = vertex.index;
@@ -332,7 +334,8 @@ class Partitioning
 
       ASSERT_NOTEQUAL(current, NULL_PID);
 
-      m_partitionWeight[current] -= m_graph->weightOf(vertex);
+      m_partitionWeight[current] -= m_graph->hasUnitVertexWeight() ? \
+          m_graph->weightOf<false>(vertex) : m_graph->weightOf<true>(vertex);
       m_assignment[index] = NULL_PID;
     }
 
@@ -344,7 +347,7 @@ class Partitioning
      *
      * @return The assignment.
      */
-    inline pid_type getAssignment(
+    pid_type getAssignment(
         Vertex const vertex) const noexcept
     {
       ASSERT_LESS(vertex.index, m_assignment.size());
@@ -360,7 +363,7 @@ class Partitioning
      *
      * @return The assignment.
      */
-    inline pid_type getAssignment(
+    pid_type getAssignment(
         vtx_type const vertex) const noexcept
     {
       ASSERT_LESS(vertex, m_assignment.size());
@@ -376,7 +379,7 @@ class Partitioning
      *
      * @return True if the vertex has been assigned to a partition.
      */
-    inline bool isAssigned(
+    bool isAssigned(
         Vertex const vertex) const noexcept
     {
       return getAssignment(vertex) != NULL_PID;
@@ -390,7 +393,7 @@ class Partitioning
     *
     * @return The weight of the partition.
     */
-    inline wgt_type getWeight(
+    wgt_type getWeight(
         pid_type const partition) const noexcept
     {
       ASSERT_LESS(partition, m_partitionWeight.size());
@@ -405,7 +408,7 @@ class Partitioning
     *
     * @return The fraction of weight.
     */
-    inline double getFraction(
+    double getFraction(
         pid_type const partition) const noexcept
     {
       ASSERT_LESS(partition, m_partitionWeight.size());
@@ -419,7 +422,7 @@ class Partitioning
     *
     * @return The iterator.
     */
-    inline Iterator begin() const noexcept
+    Iterator begin() const noexcept
     {
       return Iterator(0, m_partitionWeight.data());
     }
@@ -430,7 +433,7 @@ class Partitioning
     *
     * @return The iterator.
     */
-    inline Iterator end() const noexcept
+    Iterator end() const noexcept
     {
       return Iterator(m_partitionWeight.size(), m_partitionWeight.data());
     }

--- a/src/partition/test/TwoWayConnectivity_test.cpp
+++ b/src/partition/test/TwoWayConnectivity_test.cpp
@@ -149,7 +149,7 @@ UNITTEST(TwoWayConnectivity, UpdateNeighbor)
     Vertex const u = g.destinationOf(edge);
     pid_type const where = p.getAssignment(u);
     int const status = \
-        conn.updateNeighbor(u, g.weightOf(edge), \
+        conn.updateNeighbor(u, g.weightOf<true>(edge), \
         TwoWayConnectivity::getDirection(1, where));
     if (u == 5) {
       testEqual(status, TwoWayConnectivity::BORDER_REMOVED);
@@ -221,7 +221,7 @@ UNITTEST(TwoWayConnectivity, MoveAndUpdate)
   p.move(Vertex::make(0), 1);
   for (Edge const & edge : g.edgesOf(Vertex::make(0))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
         TwoWayConnectivity::getDirection(1, where));
   }
 
@@ -234,7 +234,7 @@ UNITTEST(TwoWayConnectivity, MoveAndUpdate)
   p.move(Vertex::make(2), 0);
   for (Edge const & edge : g.edgesOf(Vertex::make(2))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
         TwoWayConnectivity::getDirection(0, where));
   }
 
@@ -247,7 +247,7 @@ UNITTEST(TwoWayConnectivity, MoveAndUpdate)
   p.move(Vertex::make(0), 0);
   for (Edge const & edge : g.edgesOf(Vertex::make(0))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
         TwoWayConnectivity::getDirection(0, where));
   }
 
@@ -344,7 +344,7 @@ UNITTEST(TwoWayConnectivity, Verify)
   p.move(Vertex::make(0), 1);
   for (Edge const edge : g.edgesOf(Vertex::make(0))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
         TwoWayConnectivity::getDirection(1, where));
   }
   testTrue(conn.verify(&g, &p));
@@ -353,7 +353,7 @@ UNITTEST(TwoWayConnectivity, Verify)
   p.move(Vertex::make(2), 0);
   for (Edge const edge : g.edgesOf(Vertex::make(2))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
         TwoWayConnectivity::getDirection(0, where));
   }
   testTrue(conn.verify(&g, &p));
@@ -362,7 +362,7 @@ UNITTEST(TwoWayConnectivity, Verify)
   p.move(Vertex::make(0), 0);
   for (Edge const edge : g.edgesOf(Vertex::make(0))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
         TwoWayConnectivity::getDirection(0, where));
   }
 

--- a/src/partition/test/TwoWayConnectivity_test.cpp
+++ b/src/partition/test/TwoWayConnectivity_test.cpp
@@ -149,7 +149,7 @@ UNITTEST(TwoWayConnectivity, UpdateNeighbor)
     Vertex const u = g.destinationOf(edge);
     pid_type const where = p.getAssignment(u);
     int const status = \
-        conn.updateNeighbor(u, g.weightOf<true>(edge), \
+        conn.updateNeighbor(u, g.weightOf<false>(edge), \
         TwoWayConnectivity::getDirection(1, where));
     if (u == 5) {
       testEqual(status, TwoWayConnectivity::BORDER_REMOVED);
@@ -221,7 +221,7 @@ UNITTEST(TwoWayConnectivity, MoveAndUpdate)
   p.move(Vertex::make(0), 1);
   for (Edge const & edge : g.edgesOf(Vertex::make(0))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<false>(edge), \
         TwoWayConnectivity::getDirection(1, where));
   }
 
@@ -234,7 +234,7 @@ UNITTEST(TwoWayConnectivity, MoveAndUpdate)
   p.move(Vertex::make(2), 0);
   for (Edge const & edge : g.edgesOf(Vertex::make(2))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<false>(edge), \
         TwoWayConnectivity::getDirection(0, where));
   }
 
@@ -247,7 +247,7 @@ UNITTEST(TwoWayConnectivity, MoveAndUpdate)
   p.move(Vertex::make(0), 0);
   for (Edge const & edge : g.edgesOf(Vertex::make(0))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<false>(edge), \
         TwoWayConnectivity::getDirection(0, where));
   }
 
@@ -344,7 +344,7 @@ UNITTEST(TwoWayConnectivity, Verify)
   p.move(Vertex::make(0), 1);
   for (Edge const edge : g.edgesOf(Vertex::make(0))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<false>(edge), \
         TwoWayConnectivity::getDirection(1, where));
   }
   testTrue(conn.verify(&g, &p));
@@ -353,7 +353,7 @@ UNITTEST(TwoWayConnectivity, Verify)
   p.move(Vertex::make(2), 0);
   for (Edge const edge : g.edgesOf(Vertex::make(2))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<false>(edge), \
         TwoWayConnectivity::getDirection(0, where));
   }
   testTrue(conn.verify(&g, &p));
@@ -362,7 +362,7 @@ UNITTEST(TwoWayConnectivity, Verify)
   p.move(Vertex::make(0), 0);
   for (Edge const edge : g.edgesOf(Vertex::make(0))) {
     pid_type const where = p.getAssignment(g.destinationOf(edge));
-    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<true>(edge), \
+    conn.updateNeighbor(g.destinationOf(edge), g.weightOf<false>(edge), \
         TwoWayConnectivity::getDirection(0, where));
   }
 


### PR DESCRIPTION
This fixes #4, and reduces runtime marginally, but memory by ~25%.